### PR TITLE
fix MakeCredential return value error

### DIFF
--- a/objectutil/credential.go
+++ b/objectutil/credential.go
@@ -50,5 +50,14 @@ func MakeCredential(rand io.Reader, key *tpm2.Public, credential tpm2.Digest, ob
 		return nil, nil, fmt.Errorf("cannot apply outer wrapper: %w", err)
 	}
 
+	credentialBlob, err = mu.MarshalToBytes(credentialBlob)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot marshal credential bytes: %w", err)
+	}
+	
+	secret, err = mu.MarshalToBytes(secret)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot marshal secret bytes: %w", err)
+	}
 	return credentialBlob, secret, nil
 }


### PR DESCRIPTION
Return value in 
`func MakeCredential(rand io.Reader, key *tpm2.Public, credential tpm2.Digest, objectName tpm2.Name) (credentialBlob tpm2.IDObject, secret tpm2.EncryptedSecret, err error)`

The prototypes of credentialBlob tpm2.IDObject and secret tpm2.EncryptedSecret are respectively IDObject corresponding to the TPM2B_ID_OBJECT type. EncryptedSecret corresponds to the TPM2B_ENCRYPTED_SECRET type.
The prototypes of these two types are as follows
```
/* Definition of TPM2B_ID_OBJECT Structure <INOUT> */
typedef struct {
    UINT16 size;
    BYTE credential[sizeof(TPMS_ID_OBJECT)];
} TPM2B_ID_OBJECT;
/* Definition of TPM2B_ENCRYPTED_SECRET Structure */
typedef struct {
    UINT16 size;
    BYTE secret[sizeof(TPMU_ENCRYPTED_SECRET)];
} TPM2B_ENCRYPTED_SECRET;
```
The first two bytes in each structure identify the length of the content, which is not included in the original code, so the fix is as follows:
```
func MakeCredential(rand io.Reader, key *tpm2.Public, credential tpm2.Digest, objectName tpm2.Name) (credentialBlob tpm2.IDObject, secret tpm2.EncryptedSecret, err error) {
...
credentialBlob, err = mu.MarshalToBytes(credentialBlob)
if err != nil {
return nil, nil, fmt.Errorf("cannot marshal credential bytes: %w", err)
}
	
secret, err = mu.MarshalToBytes(secret)
if err != nil {
return nil, nil, fmt.Errorf("cannot marshal secret bytes: %w", err)
}
return credentialBlob, secret, nil
}
```